### PR TITLE
Initial accordion port

### DIFF
--- a/elements/accordion/static/index.css.js
+++ b/elements/accordion/static/index.css.js
@@ -1,0 +1,106 @@
+import { css } from 'https://cdn.pika.dev/lit-element/v2';
+
+export const styles = css`
+:host {
+  display: block;
+  margin: 0;
+  padding: 0;
+  border: 2px solid hsl(0, 0%, 82%);
+  border-radius: 7px;
+  width: 20em;
+}
+
+:host(:focus-within) {
+  border-color: hsl(216, 94%, 73%);
+}
+
+:host(:focus-within) .Accordion-trigger {
+  background-color: hsl(0, 0%, 97%);
+}
+
+:host > * + * {
+  border-top: 1px solid hsl(0, 0%, 82%);
+}
+
+.Accordion-trigger {
+  background: none;
+  color: hsl(0, 0%, 13%);
+  display: block;
+  font-size: 1rem;
+  font-weight: normal;
+  margin: 0;
+  padding: 1em 1.5em;
+  position: relative;
+  text-align: left;
+  width: 100%;
+  outline: none;
+}
+
+:host(:focus-within) .Accordion-trigger:focus,
+.Accordion-trigger:hover,
+:host(:focus-within) .Accordion-trigger:hover {
+  background: hsl(216, 94%, 94%);
+}
+
+:host *:first-child .Accordion-trigger {
+  border-radius: 5px 5px 0 0;
+}
+
+button {
+  border-style: none;
+}
+
+:host button::-moz-focus-inner {
+  border: 0;
+}
+
+.Accordion-title {
+  display: block;
+  pointer-events: none;
+  border: transparent 2px solid;
+  border-radius: 5px;
+  padding: 0.25em;
+  outline: none;
+}
+
+.Accordion-trigger:focus .Accordion-title {
+  border-color: hsl(216, 94%, 73%);
+}
+
+.Accordion-icon {
+  border: solid hsl(0, 0%, 62%);
+  border-width: 0 2px 2px 0;
+  height: 0.5rem;
+  pointer-events: none;
+  position: absolute;
+  right: 2em;
+  top: 50%;
+  transform: translateY(-60%) rotate(45deg);
+  width: 0.5rem;
+}
+
+.Accordion-trigger:focus .Accordion-icon,
+.Accordion-trigger:hover .Accordion-icon {
+  border-color: hsl(216, 94%, 73%);
+}
+
+.Accordion-trigger[aria-expanded="true"] .Accordion-icon {
+  transform: translateY(-50%) rotate(-135deg);
+}
+
+.Accordion-panel {
+  margin: 0;
+  padding: 1em 1.5em;
+}
+
+/* For Edge bug https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4806035/ */
+.Accordion-panel[hidden] {
+  display: none;
+}
+
+::slotted([slot^="trigger"]) {
+  pointer-events: none;
+  margin: 0;
+  padding: 0;
+}
+`;

--- a/elements/accordion/static/index.html
+++ b/elements/accordion/static/index.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html>
+<head>
+  <script src="/node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+  <script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <title>a11y-accordion</title>
+  <style>
+    fieldset {
+      border: 0;
+      margin: 0;
+      padding: 0;
+    }
+
+    input {
+      border: 1px solid hsl(0, 0%, 62%);
+      border-radius: 0.3em;
+      display: block;
+      font-size: inherit;
+      padding: 0.3em 0.5em;
+    }
+  </style>
+</head>
+  <body>
+    <a11y-accordion>
+      <h3 slot="trigger-0">
+        Personal Information
+      </h3>
+      <div slot="content-0">
+        <fieldset>
+          <p>
+            <label for="cufc1">
+              Name
+              <span aria-hidden="true">
+                *
+              </span>
+              :
+            </label>
+            <input type="text"
+                  value=""
+                  name="Name"
+                  id="cufc1"
+                  class="required"
+                  aria-required="true">
+          </p>
+          <p>
+            <label for="cufc2">
+              Email
+              <span aria-hidden="true">
+                *
+              </span>
+              :
+            </label>
+            <input type="text"
+                  value=""
+                  name="Email"
+                  id="cufc2"
+                  aria-required="true">
+          </p>
+          <p>
+            <label for="cufc3">
+              Phone:
+            </label>
+            <input type="text"
+                  value=""
+                  name="Phone"
+                  id="cufc3">
+          </p>
+          <p>
+            <label for="cufc4">
+              Extension:
+            </label>
+            <input type="text"
+                  value=""
+                  name="Ext"
+                  id="cufc4">
+          </p>
+          <p>
+            <label for="cufc5">
+              Country:
+            </label>
+            <input type="text"
+                  value=""
+                  name="Country"
+                  id="cufc5">
+          </p>
+          <p>
+            <label for="cufc6">
+              City/Province:
+            </label>
+            <input type="text"
+                  value=""
+                  name="City_Province"
+                  id="cufc6">
+          </p>
+        </fieldset>
+      </div>
+      <h3 slot="trigger-1">
+        Billing Address
+      </h3>
+      <div slot="content-1">
+        <fieldset>
+          <p>
+            <label for="b-add1">
+              Address 1:
+            </label>
+            <input type="text"
+                  name="b-add1"
+                  id="b-add1">
+          </p>
+          <p>
+            <label for="b-add2">
+              Address 2:
+            </label>
+            <input type="text"
+                  name="b-add2"
+                  id="b-add2">
+          </p>
+          <p>
+            <label for="b-city">
+              City:
+            </label>
+            <input type="text"
+                  name="b-city"
+                  id="b-city">
+          </p>
+          <p>
+            <label for="b-state">
+              State:
+            </label>
+            <input type="text"
+                  name="b-state"
+                  id="b-state">
+          </p>
+          <p>
+            <label for="b-zip">
+              Zip Code:
+            </label>
+            <input type="text"
+                  name="b-zip"
+                  id="b-zip">
+          </p>
+        </fieldset>
+      </div>
+      <h3 slot="trigger-2">
+        Shipping Address
+      </h3>
+      <div slot="content-2">
+        <fieldset>
+          <p>
+            <label for="m-add1">
+              Address 1:
+            </label>
+            <input type="text"
+                  name="m-add1"
+                  id="m-add1">
+          </p>
+          <p>
+            <label for="m-add2">
+              Address 2:
+            </label>
+            <input type="text"
+                  name="m-add2"
+                  id="m-add2">
+          </p>
+          <p>
+            <label for="m-city">
+              City:
+            </label>
+            <input type="text"
+                  name="m-city"
+                  id="m-city">
+          </p>
+          <p>
+            <label for="m-state">
+              State:
+            </label>
+            <input type="text"
+                  name="m-state"
+                  id="m-state">
+          </p>
+          <p>
+            <label for="m-zip">
+              Zip Code:
+            </label>
+            <input type="text"
+                  name="m-zip"
+                  id="m-zip">
+          </p>
+        </fieldset>
+      </div>
+
+    </a11y-accordion>
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/elements/accordion/static/index.js
+++ b/elements/accordion/static/index.js
@@ -1,0 +1,96 @@
+import { LitElement, html } from 'https://cdn.pika.dev/lit-element/v2';
+import { styles } from './index.css.js';
+
+class A11yAccordion extends LitElement {
+  static get styles() {
+    return [styles];
+  }
+  static get properties() {
+    return {
+      current: {type: Number},
+      sections: {type: Array}
+    }
+  }
+  constructor() {
+    super();
+    this.focusIndex = 0;
+    this.current = 0;
+    this.sections = [0,1,2];
+    this.handleKeydown = this.handleKeydown.bind(this);
+  }
+  bindKeydown(e) {
+    const { target } = e;
+    target.addEventListener('keydown', this.handleKeydown);
+  }
+  unbindKeydown(e) {
+    const { target } = e;
+    target.removeEventListener('keydown', this.handleKeydown);
+  }
+  handleKeydown(e) {
+    const { code, target } = e;
+    const triggers = this.shadowRoot.querySelectorAll('.Accordion-trigger');
+    switch (code) {
+      case 'ArrowDown': {
+        const target = (triggers.length + this.focusIndex + 1) % triggers.length;
+        triggers[target].focus();
+        break;
+      }
+      case 'ArrowUp': {
+        const target = (triggers.length + this.focusIndex - 1) % triggers.length;
+        triggers[target].focus();
+        break;
+      }
+      case 'Home':
+        triggers[0].focus();
+        break;
+      case 'End':
+        triggers[triggers.length - 1].focus();
+        break;
+      default:
+        break;
+    }
+  }
+  renderTrigger(index) {
+    return html`
+      <button
+        class="Accordion-trigger"
+        aria-controls=${`sect${index}`}
+        aria-expanded=${this.current === index ? 'true' : 'false'}
+        id=${`accordion${index}id`}
+        @blur=${this.unbindKeydown}
+        @click=${e => this.current = index}
+        @focus=${(e) => {
+          this.focusIndex = index;
+          this.bindKeydown(e);
+        }}
+      >
+        <slot name=${`trigger-${index}`}></slot>
+        <span class="Accordion-icon"></span>
+      </button>
+    `;
+  }
+  renderContent(index) {
+    return html`
+      <div
+        class="Accordion-panel"
+        role="region"
+        aria-labelledby=${`accordion${index}id`}
+        id=${`sect${index}`}
+        ?hidden=${this.current !== index}
+      >
+        <slot name=${`content-${index}`}></slot>
+      </div>
+    `;
+  }
+  renderSection(index) {
+    return html`
+      ${this.renderTrigger(index)}
+      ${this.renderContent(index)}
+    `;
+  }
+  render() {
+    return html`${this.sections.map((section) => this.renderSection(section))}`;
+  }
+}
+
+customElements.define('a11y-accordion', A11yAccordion);


### PR DESCRIPTION
Add a direct port of https://www.w3.org/TR/wai-aria-practices/examples/accordion/accordion.html

Major alterations:
- Trigger content was moved to `[slot^="trigger-"]`
- Section content was moved to `[slot^="content-"]`
- `.focus` was updated to `:focus-within`
- `.Accordion` was updated to `:host`, there is also room for simplification in the styles by removing the namespacing on the rest of the classes
- `h3` was externalized so that the content can more flexibly meet the header order of the parent document
- *!! SURPRISING REQUIREMENT !!* needed to prevent the external elements from stealing `focus` events by using the following code to ensure the `button`s in the shadow DOM always received `focus`/`blur` events which are being used to conditionally add and remove keyboard listeners.
```
::slotted([slot^="trigger"]) {
  pointer-events: none;
}
```