### PR TITLE
Initial alert port

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ My approach is going to look like this:
 3. Implement this smarter, more flexible version.
 4. Ship it to NPM with all the best suggestions for doing so, a la: https://justinfagnani.com/2019/11/01/how-to-publish-web-components-to-npm
 
-Along the way, I might look into moving this repo towards Lerna and implementing some of the reccomendations from open-wc.org, but for now, I'm just getting started. If you come along for the ride, please feel free to submit issues or PRs to get in on that action. For now, the things I'm looking at are as follows:
+Along the way, I might look into moving this repo towards Lerna and implementing some of the reccomendations from open-wc.org, but for now, I'm just getting started. If you come along for the ride, please feel free to submit issues or PRs to get in on that action. For now, the things I'm looking are listed below.
 
-| a11y-element  | Initial port | Technical proposal | Final implementation |
+## Status
+
+| a11y-element  | w3c spec | Initial port | Technical proposal | Final implementation |
 | ------------- | ------------- | ------------- | ------------- |
-| a11y-accordion  | In progress  | TK  | TK |
-| what's next?  |  |  |  |
+| a11y-accordion  | [spec](https://www.w3.org/TR/wai-aria-practices/#accordion) [example](https://www.w3.org/TR/wai-aria-practices/examples/accordion/accordion.html) | [In progress](https://github.com/Westbrook/a11y-elements/pull/1)  | TK  | TK |
+| a11y-alert  | [spec](https://www.w3.org/TR/wai-aria-practices/#alert) [example](https://www.w3.org/TR/wai-aria-practices/examples/alert/alert.html)  | [In progress](https://github.com/Westbrook/a11y-elements/pull/3)  | TK  | TK |
+| what's next?  |  |  |  |  |

--- a/elements/alert/static/index.css.js
+++ b/elements/alert/static/index.css.js
@@ -1,0 +1,15 @@
+import { css } from 'https://cdn.pika.dev/lit-element/v2';
+
+export const styles = css`
+:host {
+  display: block;
+  padding: 10px;
+  border: 2px solid hsl(206, 74%, 54%);
+  border-radius: 4px;
+  background: hsl(206, 74%, 90%);
+}
+
+:host(:empty) {
+  display: none;
+}
+`;

--- a/elements/alert/static/index.html
+++ b/elements/alert/static/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+  <script src="/node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+  <script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <title>LitElement Example</title>
+</head>
+  <body>
+    <p>This is text that the reader has to read first in order to be "alerted" that new content is available.</p>
+    <button>Alert</button>
+    <a11y-alert></a11y-alert>
+    <script type="module">
+      import './index.js';
+      document.querySelector('button').addEventListener('click', () => {
+        document.querySelector('a11y-alert').innerHTML = '<span lang="da">Hej</span>, hello, <span lang="it">ciao</span>, <span lang="ja">こんにちは</span>, <span lang="ko">안녕</span>'
+      })
+    </script>
+  </body>
+</html>

--- a/elements/alert/static/index.js
+++ b/elements/alert/static/index.js
@@ -1,0 +1,26 @@
+import { LitElement, html } from 'https://cdn.pika.dev/lit-element/v2';
+import { styles } from './index.css.js';
+
+class A11yAlert extends LitElement {
+  static get styles() {
+      return [styles];
+  }
+  render() {
+    return html`
+      <slot></slot>
+    `;
+  }
+  firstUpdated() {
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'alert');
+    }
+    if (!this.hasAttribute('aria-live')) {
+      this.setAttribute('aria-live', 'assertive');
+    }
+    if (!this.hasAttribute('aria-atomic')) {
+      this.setAttribute('aria-atomic', 'true');
+    }
+  }
+}
+
+customElements.define('a11y-alert', A11yAlert);


### PR DESCRIPTION
Add a direct port of https://www.w3.org/TR/wai-aria-practices/examples/alert/alert.html

Major alterations:
- self manage the application of aria attributes
- switch `[role="alert"]` to `:host` in styles

This uses the `<slot>` to accept data from the outside. That means we're externalizing the data management process. This can be useful in some cases, but I think in the more fully fleshed out implementation that we'd benefit from having at least as a separate version an extension that places listeners on `parentElement` or `body` to receive events calling for the alert to set data into itself...later, though.

There is going to be lots of fun to be had with the styles on this one. They leave a lot to be asked for now, and rely on `:empty` which can be easily tricked with `<a11y-alert> </a11y-alert>`...look at that space preventing the element from actually being "empty"!